### PR TITLE
Include recipe license

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,6 +8,7 @@ class Exiv2Conan(ConanFile):
     license = "GNU GPL2"
     url = "https://github.com/Exiv2/exiv2"
     settings = "os", "compiler", "build_type", "arch"
+    exports = "LICENSE"
 
     options = {
         "shared": [True, False],


### PR DESCRIPTION
Sorry, I overlooked the fact that the license of the recipe was not being copied.

This is the last bit to get it included in Conan Center. Thanks!

closes #1 